### PR TITLE
Split var line on \r\n and \n

### DIFF
--- a/jquery.transposer.js
+++ b/jquery.transposer.js
@@ -222,7 +222,7 @@
       $(this).before(keysHtml);
 
       var output = [];
-      var lines = $(this).text().split("\n");
+      var lines = $(this).text().split(/\r\n|\n/g);
       var line, tmp = "";
 
       for (var i = 0; i < lines.length; i++) {


### PR DESCRIPTION
Noticed the jquery plugin didn't like strings with \r\n and only worked with \n. Split now happens on both \r\n and \n.